### PR TITLE
Tambahkan interaksi pengguna saat instalasi

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,3 +308,98 @@ Jika script ini berguna, please give a star ⭐ pada repository ini!
 **Version**: 2.0.0  
 **Last Updated**: 2024  
 **Tested On**: Debian 11+, Ubuntu 22.04+
+
+# Installation Options
+
+## Interactive Installation (Default)
+```bash
+# Download and run with user prompts
+wget -O install.sh https://raw.githubusercontent.com/your-repo/modern-tunneling-autoscript/main/install.sh
+chmod +x install.sh
+./install.sh
+```
+
+## Non-Interactive Installation (Recommended for Automation)
+
+### Quick Install (Fully Automated)
+```bash
+# One-command installation - completely automated
+curl -fsSL https://raw.githubusercontent.com/your-repo/modern-tunneling-autoscript/main/quick-install.sh | bash
+
+# Or with wget
+wget -O - https://raw.githubusercontent.com/your-repo/modern-tunneling-autoscript/main/quick-install.sh | bash
+```
+
+### Manual Installation with Options
+```bash
+# Download first, then run with options
+wget -O install.sh https://raw.githubusercontent.com/your-repo/modern-tunneling-autoscript/main/install.sh
+chmod +x install.sh
+
+# Non-interactive mode (no user prompts)
+./install.sh --non-interactive
+
+# Auto-answer yes to all prompts
+./install.sh --yes
+
+# Force reinstallation even if already installed
+./install.sh --force --yes
+
+# Show help
+./install.sh --help
+```
+
+### Advanced Usage
+```bash
+# Via curl with options
+curl -fsSL https://raw.githubusercontent.com/your-repo/modern-tunneling-autoscript/main/install.sh | bash -s -- --non-interactive
+
+# Force reinstall via pipe
+curl -fsSL https://raw.githubusercontent.com/your-repo/modern-tunneling-autoscript/main/install.sh | bash -s -- --force --yes
+
+# Quick install with custom options
+curl -fsSL https://raw.githubusercontent.com/your-repo/modern-tunneling-autoscript/main/quick-install.sh | bash -s -- --force
+```
+
+## Installation Options Reference
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--non-interactive` | - | Run in completely non-interactive mode (no user input required) |
+| `--yes` | `-y` | Automatically answer "yes" to all prompts |
+| `--force` | `-f` | Force reinstallation even if already installed |
+| `--help` | `-h` | Show help information |
+
+## Timeout Handling
+
+The installation script now includes automatic timeout handling:
+- User prompts timeout after 30 seconds with default answers
+- Non-interactive mode is automatically detected when running via pipe
+- No more hanging installations waiting for user input
+
+## Troubleshooting Installation Issues
+
+### Script Hangs or Gets Stuck
+If you experience hanging during installation:
+
+1. **Use non-interactive mode:**
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/your-repo/modern-tunneling-autoscript/main/quick-install.sh | bash
+   ```
+
+2. **Use timeout-safe installation:**
+   ```bash
+   ./install.sh --yes
+   ```
+
+3. **For automation/CI:**
+   ```bash
+   ./install.sh --non-interactive --force
+   ```
+
+### Common Scenarios
+
+- **Docker/Container environments:** Use `--non-interactive`
+- **CI/CD pipelines:** Use `--non-interactive --force`
+- **Remote servers:** Use the quick-install method
+- **Reinstallation:** Use `--force --yes`


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement robust non-interactive installation modes and timeouts to prevent the script from hanging when user input is expected.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous installation script would get stuck ("bisu" / silent) if user interaction was required but not provided, particularly when run in automated environments or via a pipe (e.g., `curl | bash`). This PR introduces command-line options (`--non-interactive`, `--yes`, `--force`), automatic detection of piped input, and timeouts for all user prompts, ensuring the script can complete reliably without manual intervention.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f96b49b-4be8-4782-84e7-c72269e87a69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f96b49b-4be8-4782-84e7-c72269e87a69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>